### PR TITLE
docs: add investigation issue briefs under checkito/issues

### DIFF
--- a/checkito/issues/001-async-run-color-verbose-ordering.md
+++ b/checkito/issues/001-async-run-color-verbose-ordering.md
@@ -1,0 +1,42 @@
+# Issue: asynchronous runner swaps `color` and `verbose` arguments
+
+## Summary
+The asynchronous execution path in `checkito/src/run.rs` appears to pass runtime display options in a different parameter order than the synchronous path. The private `with` function inside `run::asynchronous` takes arguments in `(verbose, color)` order, but all public entry points (`default`, `debug`, `minimal`) pass `(color, verbose)`.
+
+This can cause option inversion at runtime (e.g., `verbose = true` can be interpreted as `color = true` and vice versa), producing surprising CLI output behavior and inconsistent semantics between sync and async checks.
+
+## Why this is a problem
+- User-facing behavior is inconsistent between synchronous and asynchronous check runs.
+- Tests and docs implicitly assume these options are semantically stable across run modes.
+- Output controls (`verbose`, `color`) are critical for debugging failing properties and CI readability.
+
+## Evidence and context
+- In `run::synchronous`, the helper signature is `with(..., color, verbose, ...)` and callers pass `(color, verbose)`.
+- In `run::asynchronous`, callers pass `(color, verbose)`, but helper signature currently expects `(..., verbose, color, ...)`.
+- The helper then forwards to `prepare(..., verbose, color)`, meaning values are likely flipped before output configuration is created.
+
+## Scope
+- Primary file: `checkito/src/run.rs`.
+- Potentially affected tests: check-macro integration tests that exercise verbose/color attributes under async mode (if any).
+
+## Proposed fix plan
+1. **Add/adjust tests first (TDD):**
+   - Add focused async tests that set `color` and `verbose` independently and assert behavior from emitted output formatting path (or internal state where accessible).
+   - Ensure one test explicitly verifies that `verbose=true,color=false` does not emit ANSI color escapes.
+2. **Fix helper signature/order:**
+   - Normalize asynchronous helper signature to `(color, verbose)` to match callers and synchronous path.
+3. **Audit call chain:**
+   - Confirm argument order from macro-generated invocations into runtime API is consistent.
+4. **Regression coverage:**
+   - Add a small table-style test matrix for combinations of `(color, verbose)` in async mode.
+5. **Run full relevant test suites:**
+   - `cargo test --features check,asynchronous` (or project-standard equivalent).
+
+## Risks and caveats
+- If existing tests accidentally depended on swapped behavior, this change will break them. Those tests should be updated as they represent buggy baseline behavior.
+- Output assertions should be robust to non-deterministic panic message text; prefer explicit marker checks.
+
+## Acceptance criteria
+- Async and sync modes treat `color` and `verbose` identically for equivalent settings.
+- Added tests fail before the fix and pass after.
+- No regressions in existing check macro tests.

--- a/checkito/issues/002-check-macro-generate-error-setting-is-invalid.md
+++ b/checkito/issues/002-check-macro-generate-error-setting-is-invalid.md
@@ -1,0 +1,45 @@
+# Issue: `#[check]` macro accepts `generate.error` but runtime config has no such field
+
+## Summary
+The `checkito_macro` parser and code generator currently recognize the key `generate.error`, and emit code assigning `_checker.generate.error = ...`. However, the runtime `Generates` struct in `checkito/src/check.rs` does not define an `error` field.
+
+This creates a latent API inconsistency where the macro advertises a configuration key that cannot compile if used.
+
+## Why this is a problem
+- Produces confusing compile errors for users when they use a seemingly documented/accepted key.
+- Macro-level key validation should reject unsupported keys early and clearly.
+- Indicates drift between proc-macro configuration surface and runtime checker API.
+
+## Evidence and context
+- `checkito_macro/src/check.rs`:
+  - `Key::GenerateError` exists.
+  - String mapping returns `"generate.error"`.
+  - Update emission contains assignment to `_checker.generate.error`.
+- `checkito/src/check.rs`:
+  - `pub struct Generates` fields: `seed`, `sizes`, `count`, `items`, `exhaustive`.
+  - No `error` field exists.
+
+## Scope
+- Primary file: `checkito_macro/src/check.rs`.
+- Possibly affected docs/tests around accepted `#[check(...)]` settings.
+
+## Proposed fix plan
+1. **Write tests first:**
+   - Add macro tests ensuring unsupported keys are rejected with a clear diagnostic.
+   - Add a specific regression test for `generate.error`.
+2. **Resolve API mismatch:** choose one of:
+   - **Preferred:** remove `GenerateError` support from macro parsing and key listing.
+   - **Alternative:** add an intentional `error` field and semantics in runtime `Generates` if truly desired.
+3. **Update user-facing docs/messages:**
+   - Ensure key list in errors includes only valid keys.
+4. **Run tests:**
+   - macro crate tests + integration tests for `#[check]`.
+
+## Risks and caveats
+- Removing a previously accepted key is technically a breaking change for any user relying on it (though currently broken/useless). Consider changelog note.
+- If the key was intended for upcoming behavior, removal should include TODO or tracking issue for future feature.
+
+## Acceptance criteria
+- `generate.error` is either fully implemented end-to-end or clearly rejected by macro diagnostics.
+- No generated code references missing checker fields.
+- Key validation tests cover this mismatch.

--- a/checkito/issues/003-parallel-pool-worker-count-off-by-one.md
+++ b/checkito/issues/003-parallel-pool-worker-count-off-by-one.md
@@ -1,0 +1,42 @@
+# Issue: parallel pool worker index allocation likely under-spawns workers (off-by-one)
+
+## Summary
+`checkito/src/parallel.rs` appears to allocate worker indices in a way that may spawn fewer threads than requested. The allocator returns `Some(next)` only when `next < end`, with `start` initialized to `0` and `end` set to configured pool size.
+
+This implies the spawned index range is effectively `1..end`, i.e., `end - 1` workers, and can yield zero workers for `end = 1`.
+
+## Why this is a problem
+- Reduced parallel throughput relative to requested parallelism.
+- Edge-case risk of starvation/hang when minimal pool sizes are used.
+- Internal invariants for `ready` accounting may become difficult to reason about.
+
+## Evidence and context
+- `State::new` initializes range as `start = 0`, `end = size(...)`.
+- `State::next` computes `next = start + 1` and returns `Some(next)` only when `next < end`.
+- `State::ensure` repeatedly calls `next()` to decide spawning.
+- `State::run` includes a shrink check comparing `end < index`, which also depends on index semantics.
+
+## Scope
+- Primary file: `checkito/src/parallel.rs`.
+- Potentially affected tests or codepaths using `parallel::iterate` and pool resizing.
+
+## Proposed fix plan
+1. **Add tests first:**
+   - Unit/integration tests for exact spawned-worker count across small sizes (`1`, `2`, `3`).
+   - Verify no blocking/hang for minimal configured pool + simple producer closure.
+2. **Normalize index semantics:**
+   - Adopt either zero-based `[0, end)` or one-based `[1, end]` consistently.
+   - Update `State::next` and `State::run` shrink checks accordingly.
+3. **Revalidate accounting:**
+   - Ensure `ready.fetch_add/sub` transitions still match lifecycle.
+4. **Stress validation:**
+   - Run repeated short parallel iterations to check deterministic completion.
+
+## Risks and caveats
+- Thread-count changes can alter timing-sensitive tests.
+- Panic propagation path (`error.try_send`, resume unwind) should be rechecked after index updates.
+
+## Acceptance criteria
+- Observed active worker count matches requested count for representative sizes.
+- No deadlocks/hangs in low-parallelism scenarios.
+- Existing parallel tests pass with new targeted regression tests.

--- a/checkito/issues/004-panic-hook-global-state-race.md
+++ b/checkito/issues/004-panic-hook-global-state-race.md
@@ -1,0 +1,43 @@
+# Issue: panic hook management in `run` uses global process state without concurrency guard
+
+## Summary
+`checkito/src/run.rs` temporarily overrides the global panic hook using `panic::set_hook`, while storing/restoring the previous hook in thread-local state. Because panic hooks are process-global, concurrent or nested check runs can interfere with each other.
+
+The current implementation may still work in many cases, but it has race-prone semantics under parallel test execution.
+
+## Why this is a problem
+- Global hook replacement is inherently shared across threads.
+- Two check runs entering/exiting around the same time can restore hooks in surprising order.
+- Could lead to lost/misrouted panic formatting, flaky output, or hook leakage across tests.
+
+## Evidence and context
+- `hook::begin` takes and sets the global panic hook.
+- `hook::end` restores whichever hook is in TLS for current thread.
+- TLS storage does not serialize across threads; global hook writes still race.
+- Synchronous path wraps checks with `hook::silent`, async path has TODO noting missing equivalent behavior.
+
+## Scope
+- Primary file: `checkito/src/run.rs` (`mod hook`).
+- Indirectly affects all `#[check]` runtime behavior and panic output handling.
+
+## Proposed fix plan
+1. **Create targeted tests first:**
+   - Nested `Guard` usage test.
+   - Multi-thread test with concurrent begin/end cycles and assertion that original hook is restored.
+2. **Introduce global synchronization:**
+   - Use `Mutex` (or similar) around global hook lifecycle.
+   - Add reference-counting for nested guard scopes.
+3. **Preserve desired behavior:**
+   - Keep panic output suppression behavior for check execution.
+   - Restore original hook exactly once at outermost drop.
+4. **Validate with async path as well:**
+   - Ensure no regressions for `asynchronous` module usage.
+
+## Risks and caveats
+- Hook management is subtle and can itself become deadlock-prone if lock usage crosses panic boundaries. Keep critical section minimal.
+- Tests should avoid depending on exact panic message formatting from Rust runtime.
+
+## Acceptance criteria
+- Original hook restoration is deterministic under nested and concurrent usage.
+- No observed hook leakage between unrelated tests.
+- Check output behavior remains stable in sync and async modes.

--- a/checkito/issues/005-integration-test-check-aborts-process.md
+++ b/checkito/issues/005-integration-test-check-aborts-process.md
@@ -1,0 +1,57 @@
+# Issue: `cargo test --test check` aborts with non-unwinding panic (SIGABRT)
+
+## Summary
+Running the `check` integration test target currently aborts the test process with:
+
+- `thread caused non-unwinding panic. aborting.`
+- `signal: 6, SIGABRT`
+
+This indicates at least one panic path in the test/runtime interaction is aborting instead of unwinding, preventing full test completion.
+
+## Why this is a problem
+- Breaks CI stability and local developer confidence in test suite reliability.
+- Masks true pass/fail status of remaining tests.
+- Suggests panic-handling integration issue in runtime hooks, proc-macro-generated tests, or should-panic interactions.
+
+## Reproduction
+From repository root:
+
+```bash
+cargo test --test check -- --nocapture
+```
+
+Observed behavior:
+- Most tests in `checkito/tests/check.rs` run and print expected pass/fail lines.
+- Process aborts at end with non-unwinding panic.
+
+## Evidence and context
+- Failure is reproducible without code changes.
+- The failure appears after tests that intentionally panic (`#[should_panic]`), pointing to panic handling + hook interaction as likely subsystem.
+- `run.rs` contains custom panic hook management and async TODOs around hook silencing.
+
+## Scope
+- Test file: `checkito/tests/check.rs`.
+- Runtime files likely involved: `checkito/src/run.rs`, possibly `checkito/src/check.rs` (panic capture paths).
+
+## Investigation plan
+1. **Isolate failing test(s):**
+   - Run with `-- --nocapture --test-threads=1`.
+   - Binary-search tests via `cargo test --test check <name>`.
+2. **Enable backtraces and panic diagnostics:**
+   - `RUST_BACKTRACE=1` and optionally `RUST_BACKTRACE=full`.
+3. **Inspect panic strategy boundaries:**
+   - Confirm no `panic = "abort"` config unexpectedly applied to test target.
+   - Check for panic across FFI/non-unwind-safe boundaries.
+4. **Correlate with hook lifecycle:**
+   - Add temporary instrumentation in `hook::begin/end` to verify balanced entry/exit.
+5. **Add regression test once root cause is known.**
+
+## Potential root-cause directions
+- Re-entrant panic hook behavior interacting with `hook::panic()` or nested checks.
+- Panic during `Drop` while unwinding, escalating to abort.
+- Interaction between macro-generated test wrappers and custom runner output handling.
+
+## Acceptance criteria
+- `cargo test --test check` exits cleanly with deterministic results.
+- Root cause is documented and covered by regression test.
+- Panic output and `#[should_panic]` semantics remain correct.

--- a/checkito/issues/006-dead-code-warnings-in-core-library.md
+++ b/checkito/issues/006-dead-code-warnings-in-core-library.md
@@ -1,0 +1,42 @@
+# Issue: dead-code warnings in core library (`Modes::{state_unchecked,count}`, `utility::cast_ref`)
+
+## Summary
+Current test/build output reports dead-code warnings for internal APIs:
+- `Modes::state_unchecked`
+- `Modes::count`
+- `utility::cast_ref`
+
+These warnings indicate either incomplete feature integration or stale code paths that should be removed/refactored.
+
+## Why this is a problem
+- Warnings reduce signal/noise and can hide more important warnings.
+- Unused internal APIs increase maintenance surface and cognitive load.
+- In this project, some unused functions appear tied to optional features (e.g., parallel/panic handling), suggesting architectural drift.
+
+## Evidence
+Observed during `cargo test` and `cargo test --test check`:
+- `checkito/src/state.rs`: methods `state_unchecked` and `count` are never used.
+- `checkito/src/utility.rs`: function `cast_ref` is never used.
+
+## Scope
+- `checkito/src/state.rs`
+- `checkito/src/utility.rs`
+- potentially `checkito/src/parallel.rs` if `cast_ref` was meant to be used there under feature gates.
+
+## Proposed fix plan
+1. **Audit intended usage:**
+   - Determine whether each item is planned for near-term use (document with TODO + tests) or can be removed.
+2. **If removal is correct:**
+   - Delete dead code and update references/docs.
+3. **If retention is needed:**
+   - Wire into active codepaths and add tests proving usage.
+   - Alternatively add precise `#[allow(dead_code)]` with rationale (last resort).
+4. **Re-run full workspace tests and verify warning-free output.**
+
+## Risks and caveats
+- Removing currently-unused APIs may affect downstream users if they were `pub` and relied upon (these are `pub(crate)`/internal in current observations).
+- If feature-gated usage exists, test all relevant feature combinations before deletion.
+
+## Acceptance criteria
+- No dead-code warnings for these symbols under standard test builds.
+- Retained code has documented rationale and test coverage.

--- a/checkito/issues/007-exhaustive-numeric-generation-not-size-biased.md
+++ b/checkito/issues/007-exhaustive-numeric-generation-not-size-biased.md
@@ -1,0 +1,45 @@
+# Issue: exhaustive numeric generation ignores size-biasing toward small values
+
+## Summary
+In `checkito/src/state.rs`, integer and floating-point generators apply size-aware shrinking for `Mode::Random`, but `Mode::Exhaustive` currently enumerates raw range-space via `consume(...)` without any equivalent small-value prioritization.
+
+There are explicit TODO comments noting this gap:
+- integer generator exhaustive branch
+- floating generator exhaustive branch
+
+## Why this is a problem
+- Property testing usually benefits from exercising simpler/smaller values early.
+- When auto-switching to exhaustive mode (based on cardinality), users may observe very different discovery behavior than random mode.
+- This can reduce reproducibility intuition: identical generator config with only mode change can dramatically alter failure discovery order.
+
+## Evidence and context
+- `Mode::Random` path applies non-linear size adjustment (`shrink(...)`) for numeric ranges.
+- `Mode::Exhaustive` path maps index directly to value space via `consume` and bit transforms.
+- TODO comments directly suggest implementing small-first behavior for exhaustive as well.
+
+## Scope
+- `checkito/src/state.rs` numeric generation macros (`integer!`, `floating!`).
+- Potentially test suites that rely on exact exhaustive ordering.
+
+## Proposed fix plan
+1. **Define ordering contract first:**
+   - Decide whether exhaustive means complete coverage only, or complete coverage with deterministic *biased order*.
+2. **Add tests before implementation:**
+   - For representative ranges crossing zero, assert first N generated values are small/centered.
+   - Ensure full coverage remains exact after complete iteration.
+3. **Implement deterministic permutation/index mapping:**
+   - Keep one-to-one mapping from exhaustive index space to range values.
+   - Apply center-out or magnitude-tier ordering while preserving determinism.
+4. **Document behavior:**
+   - Explain why exhaustive ordering differs from linear ascending range order.
+5. **Regression testing:**
+   - Run state-specific tests + integration tests that may depend on ordering assumptions.
+
+## Risks and caveats
+- Changing exhaustive order may affect tests or users who implicitly relied on current enumeration order.
+- Must preserve full cardinality and avoid duplicates/skips.
+
+## Acceptance criteria
+- Exhaustive mode remains complete and deterministic.
+- Early exhaustive samples prioritize smaller-magnitude values in numeric ranges.
+- Behavior is documented and covered by focused tests.

--- a/checkito/issues/008-any-tuple-generation-duplication.md
+++ b/checkito/issues/008-any-tuple-generation-duplication.md
@@ -1,0 +1,41 @@
+# Issue: tuple-based `Any` generation duplicates weighted/indexed selection logic (missing `State::any_tuple*` helpers)
+
+## Summary
+`checkito/src/any.rs` includes a TODO to use `State::any_tuple`, and tuple generation currently implements selection logic inline. This duplicates choice behavior already conceptually similar to indexed/weighted selection for slices.
+
+Centralizing tuple-selection in `State` would reduce duplication and improve consistency across `Any` combinators.
+
+## Why this is a problem
+- Duplicated selection code is harder to audit for correctness and probability semantics.
+- Any future changes in weighting behavior require touching multiple locations.
+- Increases risk of drift between tuple `Any` and slice/vector `Any` behavior.
+
+## Evidence and context
+- `checkito/src/any.rs` has TODO comment: `Use State::any_tuple`.
+- `checkito/src/state.rs` has TODO comment: `Implement any_tuple_indexed and any_tuple_weighted`.
+- Current tuple implementation includes local weighted-selection branches and unreachable assumptions.
+
+## Scope
+- `checkito/src/any.rs`
+- `checkito/src/state.rs`
+- tests for `Any` tuple/slice/weighted generation behavior
+
+## Proposed fix plan
+1. **Test-first:**
+   - Add behavior-alignment tests ensuring tuple `Any` and equivalent slice/weighted forms produce compatible distribution/selection constraints.
+2. **Add state helpers:**
+   - Implement `State::any_tuple_indexed` and `State::any_tuple_weighted` with clear contracts.
+3. **Refactor `any.rs` tuple macro paths:**
+   - Replace local selection logic with new helpers.
+4. **Document invariants:**
+   - Why unreachable branches are safe (or remove unreachable by returning explicit fallbacks/errors if invariants can be violated).
+5. **Run full generator/shrinker tests.**
+
+## Risks and caveats
+- Distribution differences may subtly change existing probabilistic expectations.
+- Ensure cardinality calculations remain unchanged where expected.
+
+## Acceptance criteria
+- Tuple and slice-based `Any` share centralized selection logic.
+- Existing behavior is preserved or intentionally documented where changed.
+- New tests protect against regressions and invariant drift.


### PR DESCRIPTION
### Motivation
- Capture and record a focused investigation into several behavioral inconsistencies, TODOs, and test failures discovered while exercising the `checkito` codebase. 
- Provide clear, actionable issue briefs so follow-up work can be TDD-driven and scoped without redoing the initial exploration.

### Description
- Added eight investigation issue files under `checkito/issues/` describing root cause analysis, scope, and proposed TDD-first fix plans for each problem: `001-async-run-color-verbose-ordering.md`, `002-check-macro-generate-error-setting-is-invalid.md`, `003-parallel-pool-worker-count-off-by-one.md`, `004-panic-hook-global-state-race.md`, `005-integration-test-check-aborts-process.md`, `006-dead-code-warnings-in-core-library.md`, `007-exhaustive-numeric-generation-not-size-biased.md`, and `008-any-tuple-generation-duplication.md`.
- Each issue file contains evidence, a proposed stepwise fix plan (tests first), risks/caveats, and acceptance criteria to make follow-ups deterministic and reviewable.

### Testing
- Ran the repository test suite via `cargo test -q` to gather runtime behavior and diagnostics, which produced several passing unit tests but revealed a failing integration scenario; the run surfaced dead-code warnings for `Modes::state_unchecked`, `Modes::count`, and `utility::cast_ref`.
- Reproduced the failing integration target with `cargo test --test check -- --nocapture`, which demonstrated a process abort with "non-unwinding panic" / SIGABRT while exercising `checkito/tests/check.rs` and confirmed a likely panic-hook/runner interaction to investigate further.
- Verified the presence of the new issue files using file scans (`rg --files checkito/issues`) and confirmed the files were committed to the repository; these documentation changes are non-functional and do not alter runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ec48b23348330bbdf6d44d2d336d0)