### PR TITLE
Add investigation issues: sizes scale, macro env defaults, and parallel worker boundary

### DIFF
--- a/checkito/issues/009-sizes-from-ratio-resets-scale.md
+++ b/checkito/issues/009-sizes-from-ratio-resets-scale.md
@@ -1,0 +1,35 @@
+# Issue: `Sizes::from_ratio` resets `scale` to default instead of preserving configured value
+
+## Summary
+`State::random` uses `Sizes::from_ratio(index, count, sizes)` to derive a per-sample size during generation. The `from_ratio` implementation currently reconstructs `Sizes` with `Self::SCALE` (the hardcoded default) rather than reusing `size.scale()`.
+
+As a result, any non-default `Sizes` scale configured by users (or by internal combinators) is silently dropped for generated states.
+
+## Where this happens
+- `checkito/src/state.rs`
+  - `State::random` uses `Sizes::from_ratio`.
+  - `Sizes::from_ratio` returns `Self::new(..., Self::SCALE)` in both branches (`count <= 1` and `count > 1`).
+- The same file also exposes APIs that preserve/customize scale, e.g. `With::size` and `With::scale`, which suggests scale is expected to be meaningful and configurable.
+
+## Why this is an issue
+1. **Configuration inconsistency**: `Sizes` carries `scale` as part of its state, but `from_ratio` effectively discards it.
+2. **Behavior surprise**: A caller can set a custom scale and still get default-scaling behavior at runtime.
+3. **Shrinking/generation distribution drift**: integer and float generation paths use `state.scale()`, so resetting it modifies sample distribution and can change failure discovery behavior.
+4. **Hard-to-debug reproducibility differences**: users may think they are rerunning with custom scale settings when the runtime is actually using default scale.
+
+## Reproduction outline
+1. Construct a checker with a custom sizes scale (`checker.generate.sizes = checker.generate.sizes.scale(...)` via state plumbing or equivalent API path).
+2. Generate several states and inspect `state.scale()` used by numeric generation.
+3. Observe that generated states use default `Sizes::SCALE` rather than the configured scale.
+
+## Proposed fix plan
+1. Update `Sizes::from_ratio` to preserve the incoming `size.scale()` instead of `Self::SCALE`.
+2. Add unit tests in `checkito/src/state.rs` (or nearby existing test module) for both branches:
+   - `count <= 1` preserves scale.
+   - `count > 1` preserves scale.
+3. Add a behavior-level test proving custom scale actually affects generated numeric ranges (regression guard).
+4. Confirm existing generation/shrinking tests still pass.
+
+## Risk / compatibility notes
+- This is likely a bug fix, but it can change observed sample distribution for callers who already provide custom scales and were unknowingly ignored.
+- Document behavior in changelog/release notes as a correctness fix.

--- a/checkito/issues/010-check-attribute-env-vars-are-compile-time.md
+++ b/checkito/issues/010-check-attribute-env-vars-are-compile-time.md
@@ -1,0 +1,44 @@
+# Issue: `#[check]` env-based defaults (`CHECKITO_DEBUG/COLOR/VERBOSE/ASYNCHRONOUS`) are compile-time, not runtime
+
+## Summary
+The `checkito_macro` parser reads `CHECKITO_DEBUG`, `CHECKITO_COLOR`, `CHECKITO_VERBOSE`, and `CHECKITO_ASYNCHRONOUS` in `Check::new`. Because this logic is inside a proc-macro crate, these values are captured at macro expansion (compile) time.
+
+This differs from runner configuration in `checkito/src/run.rs`, which reads generation/shrinking env vars at runtime.
+
+## Where this happens
+- `checkito_macro/src/check.rs`
+  - `Check::new` initializes defaults via `parse("CHECKITO_DEBUG")`, `parse("CHECKITO_COLOR")`, `parse("CHECKITO_VERBOSE")`, and `parse("CHECKITO_ASYNCHRONOUS")`.
+- `README.md`
+  - Documents runtime environment overrides for generation/shrinking, but does not clearly document compile-time semantics for these macro defaults.
+
+## Why this is an issue
+1. **Unexpected semantics**: users generally expect `cargo test` env vars to affect current execution, not require recompilation.
+2. **Incremental build confusion**: changing env var values without forcing recompilation may have no effect.
+3. **Inconsistent model**: some env vars are runtime (`CHECKITO_GENERATE_*`, `CHECKITO_SHRINK_*`), others are compile-time (macro defaults).
+4. **CI variability risk**: different build/test stages may inadvertently apply different defaults depending on when compilation occurred.
+
+## Reproduction outline
+1. Build tests with `CHECKITO_VERBOSE=false`.
+2. Re-run tests with `CHECKITO_VERBOSE=true` **without** recompiling touched macro call sites.
+3. Observe unchanged verbosity behavior from `#[check]` expansion defaults.
+4. Force recompilation; behavior now updates.
+
+## Proposed fix plan
+Pick one explicit strategy and document it:
+
+### Option A (preferred): move defaults to runtime
+1. Stop reading these env vars inside proc-macro parsing.
+2. Thread unresolved/default options into runtime runner logic (similar to existing runtime env handling).
+3. Ensure `#[check(...)]` explicit attribute arguments still take precedence.
+
+### Option B: keep compile-time behavior but make it explicit
+1. Add clear docs that these specific env vars are compile-time macro defaults.
+2. Add compile-test/docs test showing recompilation requirement.
+3. Consider renaming vars or introducing runtime variants to reduce ambiguity.
+
+## Test plan
+- Add integration coverage demonstrating expected precedence:
+  1. explicit attribute arg,
+  2. env default,
+  3. built-in default.
+- If Option A is implemented, add runtime env tests in `checkito/tests` to ensure no recompilation dependency.

--- a/checkito/issues/011-parallel-worker-shrink-boundary.md
+++ b/checkito/issues/011-parallel-worker-shrink-boundary.md
@@ -1,0 +1,48 @@
+# Issue: parallel worker shrink boundary check appears off-by-one and may keep extra workers alive
+
+## Summary
+In `parallel::State::run`, worker shutdown on pool shrink uses:
+
+```rust
+if state.size.end.load(Ordering::Relaxed) < index {
+    state.size.start.fetch_sub(1, Ordering::Relaxed);
+    break;
+}
+```
+
+Given worker indices are compared against `end` bounds, this `< index` condition appears to permit a worker whose `index == end` to continue running, which is likely outside the intended active range.
+
+This looks related to index-boundary handling in `State::next` and could cause worker accounting mismatches when the pool size is reduced.
+
+## Where this happens
+- `checkito/src/parallel.rs`
+  - Worker allocation / index progression in `State::next`.
+  - Shrink handling condition in `State::run` (`end < index`).
+
+## Why this is an issue
+1. **Potential extra worker retention after shrink**: boundary worker may not exit when it should.
+2. **Accounting drift risk**: `size.start` and `ready` counters are subtle; keeping a stale worker can complicate invariants.
+3. **Hard-to-reproduce concurrency behavior**: bugs may only surface under dynamic resizing and load.
+4. **Related known boundary concerns**: there is already a worker-count off-by-one concern in this module; this path deserves focused verification.
+
+## Investigation notes to include in implementation work
+- Clarify intended index domain (`0..end`, `1..=end`, etc.) and document it in code comments.
+- Validate consistency among:
+  - `State::next` compare/exchange logic,
+  - `State::run` shrink exit condition,
+  - `Pool::with` size changes,
+  - `ready`/`size.start` updates.
+
+## Proposed fix plan
+1. Write targeted tests (likely stress/integration style) for dynamic pool shrink behavior:
+   - start with larger pool,
+   - shrink while tasks are active,
+   - verify expected active worker count and progress completion.
+2. Verify boundary condition; likely `<=` (or adjusted indexing model) is needed.
+3. Audit `fetch_sub` usage for underflow assumptions and ensure counters remain valid.
+4. Add inline comments explaining index convention and shrink behavior.
+
+## Acceptance criteria
+- Deterministic tests confirm no extra workers remain after shrink.
+- No hangs/starvation under repeated grow/shrink cycles.
+- Worker-count semantics are documented and internally consistent.


### PR DESCRIPTION
### Motivation
- Perform a focused codebase investigation to surface plausibly impactful correctness, ergonomics, and concurrency issues that need triage before fixing.
- Collect detailed, self-contained issue briefs so a maintainer or contributor can pick up investigations and fixes with minimal context.

### Description
- Add `checkito/issues/009-sizes-from-ratio-resets-scale.md` documenting that `Sizes::from_ratio` currently resets the `scale` field to the default instead of preserving a configured scale, with a test-first fix plan.
- Add `checkito/issues/010-check-attribute-env-vars-are-compile-time.md` documenting that `#[check]` proc-macro defaults read `CHECKITO_DEBUG/COLOR/VERBOSE/ASYNCHRONOUS` at compile/expansion time (proc-macro), including remediation options to unify runtime/compile-time semantics.
- Add `checkito/issues/011-parallel-worker-shrink-boundary.md` documenting a likely off-by-one/boundary issue in `parallel::State::run` worker shutdown logic and proposing targeted verification and tests to exercise grow/shrink scenarios.

### Testing
- Ran `cargo test -q` to observe repository test behavior and reproduction notes, which completed many unit tests but failed the integration `--test check` target due to a process abort (`SIGABRT`) on the known non-unwinding panic path, so the suite did not fully pass.
- Ran `cargo test -q --test asynchronous` which executed the asynchronous test target and completed successfully (tests passed).
- Ran other package test subsets during investigation (multiple unit test modules), which completed and passed where noted, and captured the failing integration test to include in issue context.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ec7621a448330801c4e9509fd8fda)