### PR TITLE
Fix async run color/verbose argument ordering

### DIFF
--- a/checkito/src/run.rs
+++ b/checkito/src/run.rs
@@ -48,8 +48,8 @@ impl Colors {
 fn prepare<G: Generate + ?Sized, R, U: FnOnce(&mut Checker<G, R>)>(
     checker: &mut Checker<G, R>,
     update: U,
-    verbose: bool,
     color: bool,
+    verbose: bool,
 ) -> hook::Guard<Colors> {
     checker.generate.items = verbose;
     checker.shrink.items = verbose;
@@ -230,7 +230,7 @@ pub mod synchronous {
         handle: H,
     ) {
         let mut checker = generator.checker();
-        let Guard(colors) = &prepare(&mut checker, update, verbose, color);
+        let Guard(colors) = &prepare(&mut checker, update, color, verbose);
         checker
             .checks(hook::silent(check))
             .for_each(|result| handle(result, colors));
@@ -306,12 +306,13 @@ pub mod asynchronous {
         generator: G,
         update: U,
         check: C,
-        verbose: bool,
         color: bool,
+        verbose: bool,
         handle: H,
     ) {
         let mut checker = generator.checker().asynchronous();
-        let Guard(colors) = &prepare(&mut checker, update, verbose, color);
+        // Keep the canonical run option order as `(color, verbose)`.
+        let Guard(colors) = &prepare(&mut checker, update, color, verbose);
         block_on(
             checker
                 // TODO: Is it possible to use `hook::silent` (adapted for futures) here?
@@ -483,6 +484,33 @@ mod environment {
         match env::var(key) {
             Ok(value) => value.parse().ok(),
             Err(_) => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::generate::FullGenerate;
+
+    #[test]
+    fn prepare_applies_color_and_verbose_independently() {
+        let mut checker = bool::generator().checker();
+
+        {
+            let guard = prepare(&mut checker, |_| {}, false, true);
+            assert_eq!(guard.green, "");
+            assert!(checker.generate.items);
+            assert!(checker.shrink.items);
+            assert!(checker.shrink.errors);
+        }
+
+        {
+            let guard = prepare(&mut checker, |_| {}, true, false);
+            assert_eq!(guard.green, "\x1b[32m");
+            assert!(!checker.generate.items);
+            assert!(!checker.shrink.items);
+            assert!(!checker.shrink.errors);
         }
     }
 }


### PR DESCRIPTION
## Summary
- fixed `run::prepare` and all call sites to consistently use `(color, verbose)` ordering
- corrected `run::asynchronous::with` parameter order to match the public async entry points (`default`, `debug`, `minimal`)
- added an inline comment in `run.rs` documenting the canonical argument order to prevent future regressions
- added a unit regression test (`run::tests::prepare_applies_color_and_verbose_independently`) that verifies color formatting and verbose checker flags are controlled independently

## Root cause
`asynchronous::default/debug/minimal` passed `(color, verbose)` into `with`, but `with` accepted `(verbose, color)`, so booleans were swapped before reaching `prepare`.

## Behavior change
Async run configuration now respects user intent:
- `color` controls ANSI coloring
- `verbose` controls generate/shrink item/error verbosity

## Fallback behavior
No fallback path added; this is a direct correctness fix for argument forwarding.

## Testing
- `cargo test -p checkito --features asynchronous prepare_applies_color_and_verbose_independently -- --nocapture`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f4160c4bc8330ad4d3346f34d24f6)