### PR TITLE
Organize property tests under cfg-gated #[check] modules and strengthen test assertions

### DIFF
--- a/checkito/tests/boxed.rs
+++ b/checkito/tests/boxed.rs
@@ -1,0 +1,75 @@
+pub mod common;
+use common::*;
+
+#[test]
+fn boxed_generator_supports_sampling_and_cardinality() {
+    let generator = boxed(Box::new(0u8..=2));
+
+    assert_eq!(generator.cardinality(), Some(3));
+
+    let values = generator
+        .checks(Ok::<_, ()>)
+        .map(|result| result.item())
+        .collect::<Vec<_>>();
+    assert_eq!(values, vec![0, 1, 2]);
+}
+
+#[test]
+fn boxed_downcast_succeeds_for_original_type() {
+    let generator = boxed(Box::new(0u8..=2));
+    let original = generator
+        .downcast::<std::ops::RangeInclusive<u8>>()
+        .unwrap();
+
+    assert_eq!(original, Box::new(0u8..=2));
+}
+
+#[test]
+fn boxed_downcast_failure_returns_original_generator() {
+    let generator = boxed(Box::new(0u8..=2));
+    let boxed = generator
+        .downcast::<std::ops::RangeInclusive<u16>>()
+        .unwrap_err();
+
+    assert_eq!(boxed.cardinality(), Some(3));
+    assert!(boxed.samples(32).all(|value| value <= 2));
+}
+
+#[test]
+fn boxed_shrinker_can_clone_shrink_and_failed_downcast_preserves_behavior() {
+    let mut shrinker = shrinker(boxed(Box::new(1u8..=4))).sample(1.0);
+
+    let item = shrinker.item();
+    let clone = shrinker.clone();
+    assert_eq!(item, clone.item());
+
+    let wrong = clone.downcast::<same::Same<u8>>().unwrap_err();
+    assert_eq!(wrong.item(), item);
+
+    if let Some(shrunk) = shrinker.shrink() {
+        assert!(shrunk.item() <= item);
+    } else {
+        assert_eq!(item, 1);
+    }
+}
+
+#[cfg(feature = "check")]
+mod check {
+    use super::*;
+
+    #[check(0u8..=10, 0u8..=10)]
+    fn downcast_failure_preserves_generated_range(start: u8, end: u8) {
+        let (low, high) = if start <= end {
+            (start, end)
+        } else {
+            (end, start)
+        };
+        let generator = boxed(Box::new(low..=high));
+        let boxed = generator
+            .downcast::<std::ops::RangeInclusive<u16>>()
+            .unwrap_err();
+
+        assert_eq!(boxed.cardinality(), Some(u128::from(high - low) + 1));
+        assert!(boxed.samples(32).all(|value| value >= low && value <= high));
+    }
+}

--- a/checkito/tests/check_runtime.rs
+++ b/checkito/tests/check_runtime.rs
@@ -1,0 +1,72 @@
+pub mod common;
+use common::*;
+
+use checkito::check::Result as CheckResult;
+
+#[test]
+fn result_accessors_cover_pass_and_fail_paths() {
+    let pass = (0u8..=0).checks(Ok::<_, ()>).next().unwrap();
+    assert_eq!(pass.generates(), 1);
+    assert_eq!(pass.shrinks(), 0);
+    assert_eq!(pass.state().index(), 0);
+    let pass_item = pass.clone().pass(false).unwrap();
+    assert_eq!(pass_item.item, 0);
+    assert_eq!(pass_item.proof, 0);
+    assert!(pass.clone().fail(false).is_none());
+    assert!(pass.clone().result().is_ok());
+
+    let fail = (0u8..=0).checks(|_| Err::<(), _>("x")).next().unwrap();
+    assert!(fail.clone().pass(false).is_none());
+    let fail_item = fail.clone().fail(false).unwrap();
+    assert_eq!(fail_item.cause, Cause::Disprove("x"));
+    assert!(fail.clone().result().is_err());
+    assert_eq!(fail.item(), 0);
+}
+
+#[test]
+fn fail_message_reports_disprove_and_panic_causes() {
+    let disprove = (0u8..=0).check(|_| Err::<(), _>("disproved")).unwrap();
+    assert_eq!(disprove.message(), "\"disproved\"");
+
+    let panic = (0u8..=0).check::<(), _>(|_| panic!("boom")).unwrap();
+    assert_eq!(panic.message(), "boom");
+    assert_eq!(panic.cause, Cause::Panic(Some("boom".into())));
+}
+
+#[test]
+fn checks_respect_yield_flags_and_still_report_final_failure() {
+    let mut checker = (0u8..=3).checker();
+    checker.generate.exhaustive = Some(true);
+    checker.generate.count = 4;
+    checker.generate.items = false;
+    checker.shrink.items = false;
+    checker.shrink.errors = false;
+
+    let steps = checker
+        .checks(|value| value < 2)
+        .collect::<Vec<CheckResult<u8, bool>>>();
+
+    assert_eq!(steps.len(), 1);
+    assert!(matches!(steps[0], CheckResult::Fail(_)));
+}
+
+#[cfg(feature = "check")]
+mod check {
+    use super::*;
+
+    #[check(0u8..=u8::MAX)]
+    fn result_item_round_trip_matches_generated_value(value: u8) {
+        let step = same(value).checks(Ok::<_, ()>).next().unwrap();
+        assert_eq!(step.item(), value);
+    }
+
+    #[check(0u8..=u8::MAX)]
+    fn result_accessors_match_generated_value(value: u8) {
+        let step = same(value).checks(Ok::<_, ()>).next().unwrap();
+        assert_eq!(step.generates(), 1);
+        assert_eq!(step.shrinks(), 0);
+        let pass = step.pass(false).unwrap();
+        assert_eq!(pass.item, value);
+        assert_eq!(pass.proof, value);
+    }
+}

--- a/checkito/tests/exhaustive.rs
+++ b/checkito/tests/exhaustive.rs
@@ -1,7 +1,7 @@
 pub mod common;
-use common::*;
 use checkito::state::Weight;
 use checkito::Generate;
+use common::*;
 use std::collections::HashSet;
 
 #[derive(Clone)]
@@ -42,10 +42,7 @@ fn range_can_be_forced_to_random_even_if_finite() {
         .checks(Ok::<_, ()>)
         .map(|result| result.item())
         .collect::<Vec<_>>();
-    let exhaustive_prefix = (0u8..=9)
-        .cycle()
-        .take(25)
-        .collect::<Vec<_>>();
+    let exhaustive_prefix = (0u8..=9).cycle().take(25).collect::<Vec<_>>();
 
     assert_eq!(values.len(), 25);
     assert_ne!(values, exhaustive_prefix);
@@ -179,7 +176,9 @@ fn repeat_with_cardinality_two_uses_geometric_length_buckets() {
 
 #[test]
 fn repeat_with_overflowing_initial_block_falls_back_to_minimum_length() {
-    let mut checker = ('a'..='b').collect_with::<_, String>(130usize..=132).checker();
+    let mut checker = ('a'..='b')
+        .collect_with::<_, String>(130usize..=132)
+        .checker();
     checker.generate.count = 1;
     checker.generate.exhaustive = Some(true);
 
@@ -241,4 +240,15 @@ fn repeat_with_unknown_cardinality_uses_repeat_range_generation_path() {
 
     let lengths = values.iter().map(String::len).collect::<Vec<_>>();
     assert_eq!(lengths, vec![1, 2, 3, 1, 2]);
+}
+
+#[test]
+fn convert_preserves_values_exhaustively() {
+    let values = (0u8..=4)
+        .convert::<u16>()
+        .checks(Ok::<_, ()>)
+        .map(|result| result.item())
+        .collect::<Vec<_>>();
+
+    assert_eq!(values, vec![0, 1, 2, 3, 4]);
 }

--- a/checkito/tests/filter.rs
+++ b/checkito/tests/filter.rs
@@ -42,3 +42,37 @@ fn shrinked_filter_preserves_inequality() {
     let (left, right) = fail.item.0.clone().unwrap();
     assert_ne!(left, right);
 }
+
+#[test]
+fn filter_map_with_zero_retries_can_return_none() {
+    let values = (0u8..=3)
+        .filter_map_with(0, |value| (value % 2 == 0).then_some(value / 2))
+        .checks(Ok::<_, ()>)
+        .map(|result| result.item())
+        .collect::<Vec<_>>();
+
+    assert_eq!(values, vec![Some(0), None, Some(1), None]);
+}
+
+#[test]
+fn filter_map_with_retries_calls_mapping_for_each_attempt() {
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let values = {
+        let calls = Arc::clone(&calls);
+        same(1u8)
+            .filter_map_with(4, move |value| {
+                calls.fetch_add(1, Ordering::SeqCst);
+                (value == 2).then_some(value)
+            })
+            .samples(3)
+            .collect::<Vec<_>>()
+    };
+
+    assert_eq!(values, vec![None, None, None]);
+    assert_eq!(calls.load(Ordering::SeqCst), 15);
+}

--- a/checkito/tests/prelude.rs
+++ b/checkito/tests/prelude.rs
@@ -42,3 +42,140 @@ generators!(u8, 1u8, Or1<u8>, 2u8);
 generators!(i32, 1i32, Or2<i32, i32>, 2i32, 3i32);
 generators!(char, 'a', Or3<char, char, char>, 'b', 'c', 'd');
 generators!(bool, true, Or4<bool, bool, bool, bool>, false, true, false, false);
+
+#[test]
+fn size_can_force_minimal_collections() {
+    let values = Generate::collect::<Vec<_>>(0u8..=u8::MAX)
+        .size(|_| 0.0)
+        .samples(64)
+        .collect::<Vec<_>>();
+
+    assert!(values.iter().all(Vec::is_empty));
+}
+
+#[test]
+fn dampen_with_zero_limit_forces_minimal_collections() {
+    let values = Generate::collect::<Vec<_>>(0u8..=u8::MAX)
+        .dampen_with(1.0, 8, 0)
+        .samples(64)
+        .collect::<Vec<_>>();
+
+    assert!(values.iter().all(Vec::is_empty));
+}
+
+#[test]
+fn dampen_with_zero_deepest_forces_minimal_collections() {
+    let values = Generate::collect::<Vec<_>>(0u8..=u8::MAX)
+        .dampen_with(1.0, 0, usize::MAX)
+        .samples(64)
+        .collect::<Vec<_>>();
+
+    assert!(values.iter().all(Vec::is_empty));
+}
+
+#[test]
+fn dampen_with_limit_applies_after_nested_flatten_depth() {
+    let values = same(same(
+        Generate::collect::<Vec<_>>(0u8..=u8::MAX).dampen_with(1.0, usize::MAX, 1),
+    ))
+    .flatten()
+    .flatten()
+    .samples(32)
+    .collect::<Vec<_>>();
+
+    assert!(values.iter().all(Vec::is_empty));
+}
+
+#[test]
+fn lazy_constructs_generator_only_once() {
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let lazy = {
+        let calls = Arc::clone(&calls);
+        lazy(move || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            0u8..=1
+        })
+    };
+
+    let samples = lazy.samples(128).collect::<Vec<_>>();
+
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    assert!(samples.iter().all(|value| *value <= 1));
+}
+
+#[test]
+fn standard_option_generator_covers_some_and_none() {
+    let values = <Option<bool>>::generator().samples(512).collect::<Vec<_>>();
+
+    assert!(values.iter().any(Option::is_none));
+    assert!(values.iter().any(|value| value == &Some(false)));
+    assert!(values.iter().any(|value| value == &Some(true)));
+}
+
+#[test]
+fn standard_result_generator_covers_ok_and_err() {
+    let values = <Result<bool, bool>>::generator()
+        .samples(512)
+        .collect::<Vec<_>>();
+
+    assert!(values.iter().any(|value| value == &Ok(false)));
+    assert!(values.iter().any(|value| value == &Ok(true)));
+    assert!(values.iter().any(|value| value == &Err(false)));
+    assert!(values.iter().any(|value| value == &Err(true)));
+}
+
+#[check(0u8..=u8::MAX)]
+fn converted_values_match_from_implementation(value: u8) {
+    let converted = same(value).convert::<u16>().samples(1).next().unwrap();
+    assert_eq!(converted, u16::from(value));
+}
+
+#[test]
+fn lazy_cell_generator_is_forced_and_reused() {
+    use core::cell::LazyCell;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let generator = {
+        let calls = Arc::clone(&calls);
+        LazyCell::new(move || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            0u8..=2
+        })
+    };
+
+    let values = generator.samples(64).collect::<Vec<_>>();
+
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    assert!(values.iter().all(|value| *value <= 2));
+}
+
+#[test]
+fn lazy_lock_generator_is_forced_and_reused() {
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, LazyLock,
+    };
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let generator = {
+        let calls = Arc::clone(&calls);
+        LazyLock::new(move || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            0u8..=2
+        })
+    };
+
+    let values = generator.samples(64).collect::<Vec<_>>();
+
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    assert!(values.iter().all(|value| *value <= 2));
+}

--- a/checkito/tests/sample.rs
+++ b/checkito/tests/sample.rs
@@ -1,0 +1,79 @@
+pub mod common;
+use common::*;
+
+#[test]
+fn sampler_with_same_seed_is_reproducible() {
+    let mut left = (0u8..=100).sampler();
+    left.seed = 7;
+    left.count = 64;
+
+    let mut right = (0u8..=100).sampler();
+    right.seed = 7;
+    right.count = 64;
+
+    assert_eq!(
+        left.samples().collect::<Vec<_>>(),
+        right.samples().collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn sampler_sample_respects_size_for_collections() {
+    let sampler = Generate::collect::<Vec<_>>(0u8..=u8::MAX).sampler();
+
+    assert_eq!(sampler.sample(0.0), Vec::<u8>::new());
+    assert!(sampler.sample(1.0).len() >= sampler.sample(0.0).len());
+}
+
+#[test]
+fn samples_iterator_supports_exact_size_and_double_ended_iteration() {
+    let mut samples = (0u8..=10).samples(6);
+
+    assert_eq!(samples.size_hint(), (6, Some(6)));
+    assert_eq!(samples.len(), 6);
+
+    let _ = samples.next().unwrap();
+    let _ = samples.next_back().unwrap();
+    assert_eq!(samples.len(), 4);
+
+    let _ = samples.nth(1).unwrap();
+    assert_eq!(samples.len(), 2);
+
+    let _ = samples.nth_back(0).unwrap();
+    assert_eq!(samples.len(), 1);
+
+    let _ = samples.last().unwrap();
+}
+
+#[cfg(feature = "check")]
+mod check {
+    use super::*;
+
+    #[check(0u64..=u64::MAX, 1usize..=64)]
+    fn sampler_reproducibility_holds_for_many_seeds(seed: u64, count: usize) {
+        let mut left = (0u8..=100).sampler();
+        left.seed = seed;
+        left.count = count;
+
+        let mut right = (0u8..=100).sampler();
+        right.seed = seed;
+        right.count = count;
+
+        assert_eq!(
+            left.samples().collect::<Vec<_>>(),
+            right.samples().collect::<Vec<_>>()
+        );
+    }
+
+    #[check(0u64..=u64::MAX)]
+    fn sampler_single_sample_is_reproducible(seed: u64) {
+        let mut left = (0u8..=100).sampler();
+        left.seed = seed;
+        let mut right = (0u8..=100).sampler();
+        right.seed = seed;
+
+        assert_eq!(left.sample(0.0), right.sample(0.0));
+        assert_eq!(left.sample(0.5), right.sample(0.5));
+        assert_eq!(left.sample(1.0), right.sample(1.0));
+    }
+}


### PR DESCRIPTION
### Motivation
- Align newly added generator-driven tests with the repository pattern of grouping property tests under `#[cfg(feature = "check")] mod check { ... }` for clearer feature-gating and consistency. 
- Replace low-value or brittle assertions with meaningful property-style checks using `#[check]` and generator-driven inputs. 
- Make shrink/edge-case assertions robust to generator variance to avoid spurious failures.

### Description
- Moved property-style tests into `#[cfg(feature = "check")] mod check { ... }` blocks in `checkito/tests/boxed.rs`, `checkito/tests/check_runtime.rs`, and `checkito/tests/sample.rs` and converted fixed-value checks to `#[check(...)]` where appropriate. 
- Strengthened the shrinker test in `checkito/tests/boxed.rs` to handle `None` shrink steps safely and assert monotonicity when a shrink exists. 
- Added and reorganized property checks to validate downcast-range preservation (`boxed.rs`), result/accessor round-trips (`check_runtime.rs`), and sampler reproducibility for many seeds and individual sample sizes (`sample.rs`). 
- Added small unit tests and cleanups across other test files: an exhaustive `convert_preserves_values_exhaustively` test in `exhaustive.rs`, `filter_map_with_*` tests in `filter.rs`, and multiple generator/utility tests in `prelude.rs` to increase coverage of generator semantics.

### Testing
- Ran `cargo fmt --all` to normalize formatting, which completed successfully. 
- Ran `cargo test -p checkito --test boxed --test sample --test check_runtime`, and all tests passed after making the shrinker assertion robust. 
- Ran `cargo test -p checkito --no-default-features --test boxed --test sample --test check_runtime` to confirm the suite builds and runs without the `check` feature, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ffc97a60083308c78c9da2b6039cd)